### PR TITLE
fix: Use correct SPDX license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint . --ext .js,.html",
     "start": "polymer serve"
   },
-  "license": "UNLICENSED",
+  "license": "MIT",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",


### PR DESCRIPTION
The upstream repo for this fork uses an MIT license via `LICENSE` file. We added the `package.json` file, but didn't sync the license field correctly. This fixes that.